### PR TITLE
Fix PyTorch model loading

### DIFF
--- a/binance_predict.py
+++ b/binance_predict.py
@@ -104,7 +104,10 @@ def normalize(features: np.ndarray) -> np.ndarray:
 
 
 def load_model(path: str, n_feats: int, segment_length: int):
-    obj = torch.load(path, map_location="cpu")
+    try:
+        obj = torch.load(path, map_location="cpu", weights_only=False)
+    except TypeError:
+        obj = torch.load(path, map_location="cpu")
     if isinstance(obj, dict):
         model = ConvLSTM(n_feats, conv_kernel_size=3, embedding_size=350, num_layers=1)
         model.load_state_dict(obj)


### PR DESCRIPTION
## Summary
- update `binance_predict.py` to load saved models correctly on PyTorch 2.6

## Testing
- `python -m py_compile binance_predict.py train.py lamorgia_classifier.py models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6858b781ba9483229720c21326fffa2f