### PR TITLE
Add time range support to binance_predict

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ Example:
 ```bash
 python binance_predict.py --symbol BTCUSDT --model path/to/model.pt
 ```
+
+You can also supply a specific time range with `--start` and `--end` in
+`YYYY-MM-DD HH:MM` UTC format to evaluate historical data. When a range is
+provided, the script prints pump probabilities for every segment within that
+window.


### PR DESCRIPTION
## Summary
- add optional `--start` and `--end` arguments to `binance_predict.py`
- implement helpers to fetch historical candles over a range
- print probabilities for each segment within the provided time window
- document the new feature in README

## Testing
- `python -m py_compile binance_predict.py`
- `python -m py_compile train.py lamorgia_classifier.py data/data.py`


------
https://chatgpt.com/codex/tasks/task_e_685925457b5c8322941e3533c62b1b23