### PR TITLE
Add live mode for Binance predictor

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,12 @@ You can also supply a specific time range with `--start` and `--end` in
 `YYYY-MM-DD HH:MM` UTC format to evaluate historical data. When a range is
 provided, the script prints pump probabilities for every segment within that
 window.
+
+For continuous monitoring you can run the script in *live* mode. This will
+download new data every 5 seconds (or the interval you specify) and output the
+pump probability after each update:
+
+```bash
+python binance_predict.py --symbol BTCUSDT --model path/to/model.pt \
+    --interval 5s --mode live
+```


### PR DESCRIPTION
## Summary
- add `--mode` option and live prediction loop to `binance_predict.py`
- document live mode in README

## Testing
- `python3 -m py_compile binance_predict.py`
- `pip install requests`
- `pip install numpy`

------
https://chatgpt.com/codex/tasks/task_e_6859462840b483228c76d2740b274e34